### PR TITLE
Added YouTube Video for Manual Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ translating, and enhancing code snippets.
 
 ## Install Instructions
 
-Download instructions for the latest Pieces for Developers Obsidian Plugin
+[Watch on YouTube](https://youtu.be/-88XiOa_hso): Learn how to Manually Side-Load Early Release Previews on MacOS (It's also very similar on Windows and Linux)
+
+
+Instructions for the latest Pieces for Developers Obsidian Plugin
 release: https://github.com/pieces-app/obsidian-pieces#install-instructions
 
 - Download and unzip the latest `obsidian-pieces-X.X.X` zip file


### PR DESCRIPTION
Added Link to YouTube Video that goes through installing the early preview of our Plugin as a side-loaded Obsidian Community Plugin. The Tutorial is shot on MacOS but it is similar to how it works on Windows and Linux and is still useful on those platforms.